### PR TITLE
Reed sensor driver

### DIFF
--- a/drivers/include/reed_sensor_driver.h
+++ b/drivers/include/reed_sensor_driver.h
@@ -47,7 +47,7 @@ typedef struct {
     void* no_callback;
     void* nc_callback_args;
     void* no_callback_args;
-    bool use_external_pullup;
+    bool use_external_pulldown;
 
 } reed_sensor_driver_params_t;
 

--- a/drivers/include/reed_sensor_driver.h
+++ b/drivers/include/reed_sensor_driver.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_reed_sensor_driver Reed Sensor
+ * @ingroup     drivers_sensors
+ * @brief       A high-level driver for reed sensors.
+ *
+ * @{
+ *
+ * @file
+ *
+ * @author      Timon Rupelt <timon.rupelt@haw-hamburg.de>
+ */
+
+#ifndef REED_SENSOR_DRIVER_H
+#define REED_SENSOR_DRIVER_H
+
+/* Add header includes here */
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Declare the API of the driver */
+
+
+typedef uint16_t reed_sensor_val_t;
+
+
+/**
+ * @brief   Device initialization parameters
+ */
+typedef struct {
+    /* add initialization params here */
+    gpio_t nc_pin;
+    gpio_t no_pin;
+    gpio_flank_t nc_int_flank;
+    gpio_flank_t no_int_flank;
+    void* nc_callback;
+    void* no_callback;
+    void* nc_callback_args;
+    void* no_callback_args;
+    bool use_external_pullup;
+
+} reed_sensor_driver_params_t;
+
+/**
+ * @brief   Device descriptor for the driver
+ */
+typedef struct {
+    /** Device initialization parameters */
+    reed_sensor_driver_params_t params;
+} reed_sensor_driver_t;
+
+/**
+ * @brief   Initialize a the gpio for using a reed sensor.
+ *          
+ *
+ * @param[inout] dev        Device descriptor of the driver
+ * @param[in]    params     Initialization parameters
+ *
+ * @return                  0 on success
+ */
+int reed_sensor_driver_init(reed_sensor_driver_t *dev, const reed_sensor_driver_params_t *params);
+
+/**
+ * @brief   Read value at the normaly-closed pin of the reed sensor.
+ *          
+ *
+ * @param[in]       dev     Device descriptor of the driver
+ * @param[inout]    val     Value read at the pin
+ *
+ * @return                  0 on success
+ */
+int reed_sensor_driver_read_nc(const reed_sensor_driver_t *dev, reed_sensor_val_t *val);
+
+/**
+ * @brief   Read value at the normaly-open pin of the reed sensor.
+ *          
+ *
+ * @param[in]       dev      Device descriptor of the driver
+ * @param[inout]    val     Value read at the pin
+ *
+ * @return                  0 on success
+ */
+int reed_sensor_driver_read_no(const reed_sensor_driver_t *dev, reed_sensor_val_t *val);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* REED_SENSOR_DRIVER_H */
+/** @} */

--- a/drivers/include/reed_sensor_driver.h
+++ b/drivers/include/reed_sensor_driver.h
@@ -23,6 +23,7 @@
 
 /* Add header includes here */
 #include "periph/gpio.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,11 +44,12 @@ typedef struct {
     gpio_t no_pin;
     gpio_flank_t nc_int_flank;
     gpio_flank_t no_int_flank;
-    void* nc_callback;
-    void* no_callback;
+    void (* nc_callback)(void*);
+    void (*no_callback)(void*);
     void* nc_callback_args;
     void* no_callback_args;
     bool use_external_pulldown;
+    uint32_t debounce_ms;
 
 } reed_sensor_driver_params_t;
 
@@ -91,6 +93,29 @@ int reed_sensor_driver_read_nc(const reed_sensor_driver_t *dev, reed_sensor_val_
  * @return                  0 on success
  */
 int reed_sensor_driver_read_no(const reed_sensor_driver_t *dev, reed_sensor_val_t *val);
+
+/**
+ * @brief   Default callback function for normally-open pin for debouncing.
+ *          
+ *
+ * @param[in]       args    Arguments for callback function
+ *
+ * @return                  0 on success
+ */
+void reed_sensor_driver_read_no_defaul_callback(void* args);
+
+/**
+ * @brief   Default callback function for normally-closed pin for debouncing.
+ *          
+ *
+ * @param[in]       args    Arguments for callback function
+ *
+ * @return                  0 on success
+ */
+void reed_sensor_driver_read_nc_defaul_callback(void* args);
+
+
+
 
 #ifdef __cplusplus
 }

--- a/drivers/include/reed_sensor_driver.h
+++ b/drivers/include/reed_sensor_driver.h
@@ -19,42 +19,40 @@
  */
 
 #ifndef REED_SENSOR_DRIVER_H
-#define REED_SENSOR_DRIVER_H
+#  define REED_SENSOR_DRIVER_H
 
 /* Add header includes here */
-#include "periph/gpio.h"
-#include <stdint.h>
+#  include "periph/gpio.h"
+#  include <stdint.h>
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 extern "C" {
-#endif
+#  endif
 
-/* Declare the API of the driver */
-
-
-typedef uint16_t reed_sensor_val_t;
-
+/**
+ * @brief   Sensor value type of a reed sensor.
+ */
+typedef uint8_t reed_sensor_val_t;
 
 /**
  * @brief   Device initialization parameters
  */
 typedef struct {
-    /* add initialization params here */
-    gpio_t nc_pin;
-    gpio_t no_pin;
-    gpio_flank_t nc_int_flank;
-    gpio_flank_t no_int_flank;
-    void (* nc_callback)(void*);
-    void (*no_callback)(void*);
-    void* nc_callback_args;
-    void* no_callback_args;
-    bool use_external_pulldown;
-    uint32_t debounce_ms;
+    gpio_t nc_pin;                  /**< normaly-closed pin */
+    gpio_t no_pin;                  /**< normaly-open pin */
+    gpio_flank_t nc_int_flank;      /**< interrupt flank for nc pin */
+    gpio_flank_t no_int_flank;      /**< interrupt flank for no pin */
+    void (*nc_callback)(void *);    /**< interrupt callback for no */
+    void (*no_callback)(void *);    /**< interrupt callback for nc */
+    void *nc_callback_args;         /**< callback arguments for no */
+    void *no_callback_args;         /**< interrupt callback for nc */
+    bool use_external_pulldown;     /**< flag to disable use of internal pulldown */
+    uint32_t debounce_ms;           /**< debounce delay in ms */
 
 } reed_sensor_driver_params_t;
 
 /**
- * @brief   Device descriptor for the driver
+ * @brief   Device descriptor for the reed sensor driver
  */
 typedef struct {
     /** Device initialization parameters */
@@ -63,7 +61,7 @@ typedef struct {
 
 /**
  * @brief   Initialize a the gpio for using a reed sensor.
- *          
+ *
  *
  * @param[inout] dev        Device descriptor of the driver
  * @param[in]    params     Initialization parameters
@@ -74,7 +72,7 @@ int reed_sensor_driver_init(reed_sensor_driver_t *dev, const reed_sensor_driver_
 
 /**
  * @brief   Read value at the normaly-closed pin of the reed sensor.
- *          
+ *
  *
  * @param[in]       dev     Device descriptor of the driver
  * @param[inout]    val     Value read at the pin
@@ -85,7 +83,7 @@ int reed_sensor_driver_read_nc(const reed_sensor_driver_t *dev, reed_sensor_val_
 
 /**
  * @brief   Read value at the normaly-open pin of the reed sensor.
- *          
+ *
  *
  * @param[in]       dev      Device descriptor of the driver
  * @param[inout]    val     Value read at the pin
@@ -96,30 +94,27 @@ int reed_sensor_driver_read_no(const reed_sensor_driver_t *dev, reed_sensor_val_
 
 /**
  * @brief   Default callback function for normally-open pin for debouncing.
- *          
+ *
  *
  * @param[in]       args    Arguments for callback function
  *
  * @return                  0 on success
  */
-void reed_sensor_driver_read_no_defaul_callback(void* args);
+void reed_sensor_driver_read_no_defaul_callback(void *args);
 
 /**
  * @brief   Default callback function for normally-closed pin for debouncing.
- *          
+ *
  *
  * @param[in]       args    Arguments for callback function
  *
  * @return                  0 on success
  */
-void reed_sensor_driver_read_nc_defaul_callback(void* args);
+void reed_sensor_driver_read_nc_defaul_callback(void *args);
 
-
-
-
-#ifdef __cplusplus
+#  ifdef __cplusplus
 }
-#endif
+#  endif
 
 #endif /* REED_SENSOR_DRIVER_H */
 /** @} */

--- a/drivers/reed_sensor_driver/Kconfig
+++ b/drivers/reed_sensor_driver/Kconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config MODULE_REED_SENSOR_DRIVER
+    bool "Reed Sensor"
+    depends on TEST_KCONFIG

--- a/drivers/reed_sensor_driver/Makefile
+++ b/drivers/reed_sensor_driver/Makefile
@@ -1,0 +1,2 @@
+include $(RIOTMAKE)/driver_with_saul.mk
+

--- a/drivers/reed_sensor_driver/Makefile
+++ b/drivers/reed_sensor_driver/Makefile
@@ -1,2 +1,1 @@
 include $(RIOTMAKE)/driver_with_saul.mk
-

--- a/drivers/reed_sensor_driver/Makefile.dep
+++ b/drivers/reed_sensor_driver/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/reed_sensor_driver/Makefile.include
+++ b/drivers/reed_sensor_driver/Makefile.include
@@ -1,4 +1,2 @@
 USEMODULE_INCLUDES_reed_sensor_driver := $(LAST_MAKEFILEDIR)/include
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_reed_sensor_driver)
-
-

--- a/drivers/reed_sensor_driver/Makefile.include
+++ b/drivers/reed_sensor_driver/Makefile.include
@@ -1,0 +1,4 @@
+USEMODULE_INCLUDES_reed_sensor_driver := $(LAST_MAKEFILEDIR)/include
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_reed_sensor_driver)
+
+

--- a/drivers/reed_sensor_driver/include/reed_sensor_driver_constants.h
+++ b/drivers/reed_sensor_driver/include/reed_sensor_driver_constants.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_reed_sensor_driver
+ * @{
+ *
+ * @file
+ * @brief       Internal addresses, registers and constants
+ *
+ * @author      Timon Rupelt <timon.rupelt@haw-hamburg.de>
+ */
+
+#ifndef REED_SENSOR_DRIVER_CONSTANTS_H
+#define REED_SENSOR_DRIVER_CONSTANTS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* define here the addresses, register and constants of the driver */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* REED_SENSOR_DRIVER_CONSTANTS_H */
+/** @} */

--- a/drivers/reed_sensor_driver/include/reed_sensor_driver_params.h
+++ b/drivers/reed_sensor_driver/include/reed_sensor_driver_params.h
@@ -24,7 +24,7 @@
 #include "reed_sensor_driver_constants.h"
 #include "saul_reg.h"
 
-#ifdef __cplusplus
+#  ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -33,15 +33,15 @@ extern "C" {
  * @{
  */
 #ifndef REED_SENSOR_DRIVER_PARAM_NC_PIN
-#define REED_SENSOR_DRIVER_PARAM_NC_PIN GPIO_PIN (0,8)
+#define REED_SENSOR_DRIVER_PARAM_NC_PIN GPIO_PIN(0, 8)
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_NO_PIN
-#define REED_SENSOR_DRIVER_PARAM_NO_PIN GPIO_PIN (0,6)
+#define REED_SENSOR_DRIVER_PARAM_NO_PIN GPIO_PIN(0, 6)
 #endif
-#ifndef REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK 
+#ifndef REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK
 #define REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK (GPIO_BOTH)
 #endif
-#ifndef REED_SENSOR_DRIVER_PARAM_NO_INT_FLANK 
+#ifndef REED_SENSOR_DRIVER_PARAM_NO_INT_FLANK
 #define REED_SENSOR_DRIVER_PARAM_NO_INT_FLANK (GPIO_BOTH)
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_NC_CALLBACK
@@ -54,29 +54,34 @@ extern "C" {
 #define REED_SENSOR_DRIVER_PARAM_NC_CALLBACK_ARGS (NULL)
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS
-#define REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS       (NULL)
+#define REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS (NULL)
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLDOWN
-#define REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLDOWN    (false)
+#define REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLDOWN (false)
 #endif
-
+#ifndef REED_SENSOR_DRIVER_PARAM_DEBOUNCE_MS
+#define REED_SENSOR_DRIVER_PARAM_DEBOUNCE_MS (20)
+#endif
 
 #ifndef REED_SENSOR_DRIVER_PARAMS
-#define REED_SENSOR_DRIVER_PARAMS                       { .nc_pin = REED_SENSOR_DRIVER_PARAM_NC_PIN,                            \
-                                                          .no_pin = REED_SENSOR_DRIVER_PARAM_NO_PIN,                            \
-                                                          .nc_int_flank = REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK,                \
-                                                          .no_int_flank = REED_SENSOR_DRIVER_PARAM_NO_INT_FLANK,                \
-                                                          .nc_callback = REED_SENSOR_DRIVER_PARAM_NC_CALLBACK,                  \
-                                                          .no_callback = REED_SENSOR_DRIVER_PARAM_NO_CALLBACK,                  \
-                                                          .nc_callback_args = REED_SENSOR_DRIVER_PARAM_NC_CALLBACK_ARGS,        \
-                                                          .no_callback_args = REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS,        \
-                                                          .use_external_pulldown = REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLDOWN }
+#define REED_SENSOR_DRIVER_PARAMS                                                  \
+        {                                                                            \
+            .nc_pin = REED_SENSOR_DRIVER_PARAM_NC_PIN,                               \
+            .no_pin = REED_SENSOR_DRIVER_PARAM_NO_PIN,                               \
+            .nc_int_flank = REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK,                   \
+            .no_int_flank = REED_SENSOR_DRIVER_PARAM_NO_INT_FLANK,                   \
+            .nc_callback = REED_SENSOR_DRIVER_PARAM_NC_CALLBACK,                     \
+            .no_callback = REED_SENSOR_DRIVER_PARAM_NO_CALLBACK,                     \
+            .nc_callback_args = REED_SENSOR_DRIVER_PARAM_NC_CALLBACK_ARGS,           \
+            .no_callback_args = REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS,           \
+            .use_external_pulldown = REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLDOWN, \
+            .debounce_ms = REED_SENSOR_DRIVER_PARAM_DEBOUNCE_MS }
 #endif
 #ifndef REED_SENSOR_DRIVER_NC_INFO
-#define REED_SENSOR_DRIVER_NC_INFO            { .name = "reed_sensor_nc" }
+#define REED_SENSOR_DRIVER_NC_INFO { .name = "reed_sensor_nc" }
 #endif
 #ifndef REED_SENSOR_DRIVER_NO_INFO
-#define REED_SENSOR_DRIVER_NO_INFO            { .name = "reed_sensor_no" }
+#define REED_SENSOR_DRIVER_NO_INFO { .name = "reed_sensor_no" }
 #endif
 /**@}*/
 
@@ -84,18 +89,13 @@ extern "C" {
  * @brief   Configuration struct
  */
 static const reed_sensor_driver_params_t reed_sensor_driver_params[] =
-{
-    REED_SENSOR_DRIVER_PARAMS
-};
+{ REED_SENSOR_DRIVER_PARAMS };
 
 /**
  * @brief   Additional meta information to keep in the SAUL registry
  */
-static const saul_reg_info_t reed_sensor_driver_saul_info[] =
-{
-    REED_SENSOR_DRIVER_NC_INFO,
-    REED_SENSOR_DRIVER_NO_INFO
-};
+static const saul_reg_info_t reed_sensor_driver_saul_info[] = { REED_SENSOR_DRIVER_NC_INFO,
+                                                                REED_SENSOR_DRIVER_NO_INFO };
 
 #ifdef __cplusplus
 }

--- a/drivers/reed_sensor_driver/include/reed_sensor_driver_params.h
+++ b/drivers/reed_sensor_driver/include/reed_sensor_driver_params.h
@@ -33,10 +33,10 @@ extern "C" {
  * @{
  */
 #ifndef REED_SENSOR_DRIVER_PARAM_NC_PIN
-#define REED_SENSOR_DRIVER_PARAM_NC_PIN GPIO_PIN(0,8)
+#define REED_SENSOR_DRIVER_PARAM_NC_PIN GPIO_PIN (0,8)
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_NO_PIN
-#define REED_SENSOR_DRIVER_PARAM_NO_PIN GPIO_PIN(0,6)
+#define REED_SENSOR_DRIVER_PARAM_NO_PIN GPIO_PIN (0,6)
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK 
 #define REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK (GPIO_BOTH)
@@ -56,8 +56,8 @@ extern "C" {
 #ifndef REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS
 #define REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS       (NULL)
 #endif
-#ifndef REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLUP
-#define REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLUP    (false)
+#ifndef REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLDOWN
+#define REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLDOWN    (false)
 #endif
 
 
@@ -70,7 +70,7 @@ extern "C" {
                                                           .no_callback = REED_SENSOR_DRIVER_PARAM_NO_CALLBACK,                  \
                                                           .nc_callback_args = REED_SENSOR_DRIVER_PARAM_NC_CALLBACK_ARGS,        \
                                                           .no_callback_args = REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS,        \
-                                                          .use_external_pullup = REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLUP }
+                                                          .use_external_pulldown = REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLDOWN }
 #endif
 #ifndef REED_SENSOR_DRIVER_NC_INFO
 #define REED_SENSOR_DRIVER_NC_INFO            { .name = "reed_sensor_nc" }

--- a/drivers/reed_sensor_driver/include/reed_sensor_driver_params.h
+++ b/drivers/reed_sensor_driver/include/reed_sensor_driver_params.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2024 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_reed_sensor_driver
+ *
+ * @{
+ * @file
+ * @brief       Default configuration
+ *
+ * @author      Timon Rupelt <timon.rupelt@haw-hamburg.de>
+ */
+
+#ifndef REED_SENSOR_DRIVER_PARAMS_H
+#define REED_SENSOR_DRIVER_PARAMS_H
+
+#include "board.h"
+#include "reed_sensor_driver.h"
+#include "reed_sensor_driver_constants.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters
+ * @{
+ */
+#ifndef REED_SENSOR_DRIVER_PARAM_NC_PIN
+#define REED_SENSOR_DRIVER_PARAM_NC_PIN GPIO_PIN(0,8)
+#endif
+#ifndef REED_SENSOR_DRIVER_PARAM_NO_PIN
+#define REED_SENSOR_DRIVER_PARAM_NO_PIN GPIO_PIN(0,6)
+#endif
+#ifndef REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK 
+#define REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK (GPIO_BOTH)
+#endif
+#ifndef REED_SENSOR_DRIVER_PARAM_NO_INT_FLANK 
+#define REED_SENSOR_DRIVER_PARAM_NO_INT_FLANK (GPIO_BOTH)
+#endif
+#ifndef REED_SENSOR_DRIVER_PARAM_NC_CALLBACK
+#define REED_SENSOR_DRIVER_PARAM_NC_CALLBACK (NULL)
+#endif
+#ifndef REED_SENSOR_DRIVER_PARAM_NO_CALLBACK
+#define REED_SENSOR_DRIVER_PARAM_NO_CALLBACK (NULL)
+#endif
+#ifndef REED_SENSOR_DRIVER_PARAM_NC_CALLBACK_ARGS
+#define REED_SENSOR_DRIVER_PARAM_NC_CALLBACK_ARGS (NULL)
+#endif
+#ifndef REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS
+#define REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS       (NULL)
+#endif
+#ifndef REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLUP
+#define REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLUP    (false)
+#endif
+
+
+#ifndef REED_SENSOR_DRIVER_PARAMS
+#define REED_SENSOR_DRIVER_PARAMS                       { .nc_pin = REED_SENSOR_DRIVER_PARAM_NC_PIN,                            \
+                                                          .no_pin = REED_SENSOR_DRIVER_PARAM_NO_PIN,                            \
+                                                          .nc_int_flank = REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK,                \
+                                                          .no_int_flank = REED_SENSOR_DRIVER_PARAM_NO_INT_FLANK,                \
+                                                          .nc_callback = REED_SENSOR_DRIVER_PARAM_NC_CALLBACK,                  \
+                                                          .no_callback = REED_SENSOR_DRIVER_PARAM_NO_CALLBACK,                  \
+                                                          .nc_callback_args = REED_SENSOR_DRIVER_PARAM_NC_CALLBACK_ARGS,        \
+                                                          .no_callback_args = REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS,        \
+                                                          .use_external_pullup = REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLUP }
+#endif
+#ifndef REED_SENSOR_DRIVER_NC_INFO
+#define REED_SENSOR_DRIVER_NC_INFO            { .name = "reed_sensor_nc" }
+#endif
+#ifndef REED_SENSOR_DRIVER_NO_INFO
+#define REED_SENSOR_DRIVER_NO_INFO            { .name = "reed_sensor_no" }
+#endif
+/**@}*/
+
+/**
+ * @brief   Configuration struct
+ */
+static const reed_sensor_driver_params_t reed_sensor_driver_params[] =
+{
+    REED_SENSOR_DRIVER_PARAMS
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t reed_sensor_driver_saul_info[] =
+{
+    REED_SENSOR_DRIVER_NC_INFO,
+    REED_SENSOR_DRIVER_NO_INFO
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* REED_SENSOR_DRIVER_PARAMS_H */
+/** @} */

--- a/drivers/reed_sensor_driver/include/reed_sensor_driver_params.h
+++ b/drivers/reed_sensor_driver/include/reed_sensor_driver_params.h
@@ -29,42 +29,42 @@ extern "C" {
 #endif
 
 /**
- * @name    Set default configuration parameters
+ * @name    Default comfiguration parameters for reed sensor driver
  * @{
  */
 #ifndef REED_SENSOR_DRIVER_PARAM_NC_PIN
-#define REED_SENSOR_DRIVER_PARAM_NC_PIN GPIO_PIN(0, 8)
+#define REED_SENSOR_DRIVER_PARAM_NC_PIN GPIO_PIN(0, 8)          /**< default NC pin */
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_NO_PIN
-#define REED_SENSOR_DRIVER_PARAM_NO_PIN GPIO_PIN(0, 6)
+#define REED_SENSOR_DRIVER_PARAM_NO_PIN GPIO_PIN(0, 6)          /**< default NO pin */
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK
-#define REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK (GPIO_BOTH)
+#define REED_SENSOR_DRIVER_PARAM_NC_INT_FLANK (GPIO_BOTH)       /**< default NC flank */
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_NO_INT_FLANK
-#define REED_SENSOR_DRIVER_PARAM_NO_INT_FLANK (GPIO_BOTH)
+#define REED_SENSOR_DRIVER_PARAM_NO_INT_FLANK (GPIO_BOTH)       /**< default NC flank */
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_NC_CALLBACK
-#define REED_SENSOR_DRIVER_PARAM_NC_CALLBACK (NULL)
+#define REED_SENSOR_DRIVER_PARAM_NC_CALLBACK (NULL)             /**< no NO callback by default */
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_NO_CALLBACK
-#define REED_SENSOR_DRIVER_PARAM_NO_CALLBACK (NULL)
+#define REED_SENSOR_DRIVER_PARAM_NO_CALLBACK (NULL)             /**< no NC callback by default */
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_NC_CALLBACK_ARGS
-#define REED_SENSOR_DRIVER_PARAM_NC_CALLBACK_ARGS (NULL)
+#define REED_SENSOR_DRIVER_PARAM_NC_CALLBACK_ARGS (NULL)        /**< no NO callback args by default */
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS
-#define REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS (NULL)
+#define REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS (NULL)        /**< no NO callback args by default */
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLDOWN
-#define REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLDOWN (false)
+#define REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLDOWN (false)  /**< no external pulldown by default */
 #endif
 #ifndef REED_SENSOR_DRIVER_PARAM_DEBOUNCE_MS
-#define REED_SENSOR_DRIVER_PARAM_DEBOUNCE_MS (20)
+#define REED_SENSOR_DRIVER_PARAM_DEBOUNCE_MS (20)               /**< 20 ms debounce delay by default */
 #endif
 
 #ifndef REED_SENSOR_DRIVER_PARAMS
-#define REED_SENSOR_DRIVER_PARAMS                                                  \
+#define REED_SENSOR_DRIVER_PARAMS                                                    \
         {                                                                            \
             .nc_pin = REED_SENSOR_DRIVER_PARAM_NC_PIN,                               \
             .no_pin = REED_SENSOR_DRIVER_PARAM_NO_PIN,                               \
@@ -75,13 +75,14 @@ extern "C" {
             .nc_callback_args = REED_SENSOR_DRIVER_PARAM_NC_CALLBACK_ARGS,           \
             .no_callback_args = REED_SENSOR_DRIVER_PARAM_NO_CALLBACK_ARGS,           \
             .use_external_pulldown = REED_SENSOR_DRIVER_PARAM_USE_EXTERNAL_PULLDOWN, \
-            .debounce_ms = REED_SENSOR_DRIVER_PARAM_DEBOUNCE_MS }
+            .debounce_ms = REED_SENSOR_DRIVER_PARAM_DEBOUNCE_MS }   /**< default driver params */
 #endif
 #ifndef REED_SENSOR_DRIVER_NC_INFO
-#define REED_SENSOR_DRIVER_NC_INFO { .name = "reed_sensor_nc" }
+#define REED_SENSOR_DRIVER_NC_INFO { .name = "reed_sensor_nc" }     /**< saul device name for NO pin */
 #endif
+
 #ifndef REED_SENSOR_DRIVER_NO_INFO
-#define REED_SENSOR_DRIVER_NO_INFO { .name = "reed_sensor_no" }
+#define REED_SENSOR_DRIVER_NO_INFO { .name = "reed_sensor_no" }     /**< saul device name for NC pin */
 #endif
 /**@}*/
 

--- a/drivers/reed_sensor_driver/reed_sensor_driver.c
+++ b/drivers/reed_sensor_driver/reed_sensor_driver.c
@@ -28,7 +28,7 @@ int reed_sensor_driver_init(reed_sensor_driver_t *dev, const reed_sensor_driver_
 
     dev->params = *params;
 
-    gpio_mode_t mode = params->use_external_pullup ? GPIO_IN : GPIO_IN_PU;
+    gpio_mode_t mode = params->use_external_pulldown ? GPIO_IN : GPIO_IN_PD;
 
     /* Init normally-closed pin */
     if (params->nc_callback != NULL) {

--- a/drivers/reed_sensor_driver/reed_sensor_driver.c
+++ b/drivers/reed_sensor_driver/reed_sensor_driver.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_reed_sensor_driver
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for the Reed Sensor
+ *
+ * @author      Timon Rupelt <timon.rupelt@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "reed_sensor_driver.h"
+#include "reed_sensor_driver_constants.h"
+#include "reed_sensor_driver_params.h"
+
+int reed_sensor_driver_init(reed_sensor_driver_t *dev, const reed_sensor_driver_params_t *params)
+{
+    assert(dev && params);
+
+    gpio_mode_t mode = params->use_external_pullup ? GPIO_IN : GPIO_IN_PU;
+
+    if (params->nc_callback != NULL) {
+        gpio_init_int(params->nc_pin, mode, params->nc_int_flank, params->nc_callback,
+                      params->nc_callback_args);
+    }else{
+        gpio_init(params->nc_pin, GPIO_IN);
+    }
+
+    if (params->no_callback != NULL) {
+        gpio_init_int(params->no_pin, mode, params->no_int_flank, params->no_callback,
+                      params->no_callback_args);
+    }else{
+        gpio_init(params->no_pin, GPIO_IN);
+    }
+
+    return 0;
+}
+
+int reed_sensor_driver_read_nc(const reed_sensor_driver_t *dev, reed_sensor_val_t *val){
+
+    *val = (reed_sensor_val_t) gpio_read(dev->params.nc_pin);
+
+    return 0;
+}
+int reed_sensor_driver_read_no(const reed_sensor_driver_t *dev, reed_sensor_val_t *val){
+
+    *val = (reed_sensor_val_t) gpio_read(dev->params.nc_pin);
+    
+    return 0;
+}

--- a/drivers/reed_sensor_driver/reed_sensor_driver.c
+++ b/drivers/reed_sensor_driver/reed_sensor_driver.c
@@ -21,6 +21,8 @@
 #include "reed_sensor_driver.h"
 #include "reed_sensor_driver_constants.h"
 #include "reed_sensor_driver_params.h"
+#include "ztimer.h"
+
 
 int reed_sensor_driver_init(reed_sensor_driver_t *dev, const reed_sensor_driver_params_t *params)
 {
@@ -32,32 +34,67 @@ int reed_sensor_driver_init(reed_sensor_driver_t *dev, const reed_sensor_driver_
 
     /* Init normally-closed pin */
     if (params->nc_callback != NULL) {
-        gpio_init_int(params->nc_pin, mode, params->nc_int_flank, params->nc_callback,
-                      params->nc_callback_args);
-    }else{
+        gpio_init_int(params->nc_pin, mode, params->nc_int_flank, reed_sensor_driver_read_nc_defaul_callback,
+                      (void*) params);
+    }
+    else {
         gpio_init(params->nc_pin, GPIO_IN);
     }
 
     /* Init normally-open pin */
     if (params->no_callback != NULL) {
-        gpio_init_int(params->no_pin, mode, params->no_int_flank, params->no_callback,
-                      params->no_callback_args);
-    }else{
+        gpio_init_int(params->no_pin, mode, params->no_int_flank, reed_sensor_driver_read_no_defaul_callback,
+                      (void *)params);
+    }
+    else {
         gpio_init(params->no_pin, GPIO_IN);
     }
 
     return 0;
 }
 
-int reed_sensor_driver_read_nc(const reed_sensor_driver_t *dev, reed_sensor_val_t *val){
-
-    *val = (reed_sensor_val_t) gpio_read(dev->params.nc_pin);
+int reed_sensor_driver_read_nc(const reed_sensor_driver_t *dev, reed_sensor_val_t *val)
+{
+    *val = (reed_sensor_val_t)gpio_read(dev->params.nc_pin);
 
     return 0;
 }
-int reed_sensor_driver_read_no(const reed_sensor_driver_t *dev, reed_sensor_val_t *val){
+int reed_sensor_driver_read_no(const reed_sensor_driver_t *dev, reed_sensor_val_t *val)
+{
+    *val = (reed_sensor_val_t)gpio_read(dev->params.no_pin);
 
-    *val = (reed_sensor_val_t) gpio_read(dev->params.no_pin);
-    
     return 0;
 }
+
+void reed_sensor_driver_read_no_defaul_callback(void *args)
+{   
+    reed_sensor_driver_params_t* params = (reed_sensor_driver_params_t*) args;
+
+    static ztimer_now_t no_debounce_ts = 0;
+
+    ztimer_acquire(ZTIMER_MSEC);
+    ztimer_now_t cur_ts = ztimer_now(ZTIMER_MSEC);
+    ztimer_release(ZTIMER_MSEC);
+
+    if (cur_ts - no_debounce_ts >= params->debounce_ms){
+        no_debounce_ts = cur_ts;
+        (params->no_callback)(params->no_callback_args);
+    }
+}
+
+void reed_sensor_driver_read_nc_defaul_callback(void *args)
+{   
+    reed_sensor_driver_params_t* params = (reed_sensor_driver_params_t*) args;
+
+    static ztimer_now_t nc_debounce_ts = 0;
+
+    ztimer_acquire(ZTIMER_MSEC);
+    ztimer_now_t cur_ts = ztimer_now(ZTIMER_MSEC);
+    ztimer_release(ZTIMER_MSEC);
+
+    if (cur_ts - nc_debounce_ts >= params->debounce_ms){
+        nc_debounce_ts = cur_ts;
+        (params->nc_callback)(params->nc_callback_args);
+    }
+}
+

--- a/drivers/reed_sensor_driver/reed_sensor_driver.c
+++ b/drivers/reed_sensor_driver/reed_sensor_driver.c
@@ -26,8 +26,11 @@ int reed_sensor_driver_init(reed_sensor_driver_t *dev, const reed_sensor_driver_
 {
     assert(dev && params);
 
+    dev->params = *params;
+
     gpio_mode_t mode = params->use_external_pullup ? GPIO_IN : GPIO_IN_PU;
 
+    /* Init normally-closed pin */
     if (params->nc_callback != NULL) {
         gpio_init_int(params->nc_pin, mode, params->nc_int_flank, params->nc_callback,
                       params->nc_callback_args);
@@ -35,6 +38,7 @@ int reed_sensor_driver_init(reed_sensor_driver_t *dev, const reed_sensor_driver_
         gpio_init(params->nc_pin, GPIO_IN);
     }
 
+    /* Init normally-open pin */
     if (params->no_callback != NULL) {
         gpio_init_int(params->no_pin, mode, params->no_int_flank, params->no_callback,
                       params->no_callback_args);
@@ -53,7 +57,7 @@ int reed_sensor_driver_read_nc(const reed_sensor_driver_t *dev, reed_sensor_val_
 }
 int reed_sensor_driver_read_no(const reed_sensor_driver_t *dev, reed_sensor_val_t *val){
 
-    *val = (reed_sensor_val_t) gpio_read(dev->params.nc_pin);
+    *val = (reed_sensor_val_t) gpio_read(dev->params.no_pin);
     
     return 0;
 }

--- a/drivers/reed_sensor_driver/reed_sensor_driver.c
+++ b/drivers/reed_sensor_driver/reed_sensor_driver.c
@@ -67,7 +67,7 @@ int reed_sensor_driver_read_no(const reed_sensor_driver_t *dev, reed_sensor_val_
 }
 
 void reed_sensor_driver_read_no_defaul_callback(void *args)
-{   
+{
     reed_sensor_driver_params_t* params = (reed_sensor_driver_params_t*) args;
 
     static ztimer_now_t no_debounce_ts = 0;
@@ -83,7 +83,7 @@ void reed_sensor_driver_read_no_defaul_callback(void *args)
 }
 
 void reed_sensor_driver_read_nc_defaul_callback(void *args)
-{   
+{
     reed_sensor_driver_params_t* params = (reed_sensor_driver_params_t*) args;
 
     static ztimer_now_t nc_debounce_ts = 0;
@@ -97,4 +97,3 @@ void reed_sensor_driver_read_nc_defaul_callback(void *args)
         (params->nc_callback)(params->nc_callback_args);
     }
 }
-

--- a/drivers/reed_sensor_driver/reed_sensor_driver_saul.c
+++ b/drivers/reed_sensor_driver/reed_sensor_driver_saul.c
@@ -31,9 +31,8 @@ static int read_nc(const void *dev, phydat_t *res)
     reed_sensor_driver_read_nc(d,&val);
 
     res->val[0] = val;
-    res->unit = UNIT_NONE; 
+    res->unit = UNIT_NONE;
     res->scale = 0;
-    
     return 1;
 }
 
@@ -44,9 +43,8 @@ static int read_no(const void *dev, phydat_t *res)
     reed_sensor_driver_read_no(d,&val);
 
     res->val[0] = val;
-    res->unit = UNIT_NONE; 
+    res->unit = UNIT_NONE;
     res->scale = 0;
-    
     return 1;
 }
 

--- a/drivers/reed_sensor_driver/reed_sensor_driver_saul.c
+++ b/drivers/reed_sensor_driver/reed_sensor_driver_saul.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_reed_sensor_driver
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for the Reed Sensor
+ *
+ * @author      Timon Rupelt <timon.rupelt@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "reed_sensor_driver.h"
+
+
+static int read_nc(const void *dev, phydat_t *res)
+{
+    const reed_sensor_driver_t *d = (const reed_sensor_driver_t *)dev;
+    reed_sensor_val_t val;
+    reed_sensor_driver_read_nc(d,&val);
+
+    res->val[0] = val;
+    res->unit = UNIT_NONE; 
+    res->scale = 0;
+    
+    return 1;
+}
+
+static int read_no(const void *dev, phydat_t *res)
+{
+    const reed_sensor_driver_t *d = (const reed_sensor_driver_t *)dev;
+    reed_sensor_val_t val;
+    reed_sensor_driver_read_no(d,&val);
+
+    res->val[0] = val;
+    res->unit = UNIT_NONE; 
+    res->scale = 0;
+    
+    return 1;
+}
+
+
+const saul_driver_t reed_sensor_nc_saul_driver = {
+    .read = read_nc,
+    .write = saul_write_notsup,
+    .type = SAUL_SENSE_BTN,
+};
+
+const saul_driver_t reed_sensor_no_saul_driver = {
+    .read = read_no,
+    .write = saul_write_notsup,
+    .type = SAUL_SENSE_BTN,
+};

--- a/drivers/saul/init_devs/auto_init_reed_sensor_driver.c
+++ b/drivers/saul/init_devs/auto_init_reed_sensor_driver.c
@@ -53,11 +53,11 @@ extern saul_driver_t reed_sensor_no_saul_driver;
 /** @} */
 
 
-
+#define ENABLE_DEBUG 1
+#include "debug.h"
 
 void auto_init_reed_sensor_driver(void)
 {
-    assert(RSD_INFO_NUM == RSD_NUM);
 
     for (unsigned int i = 0; i < RSD_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing rsd #%u\n", i);
@@ -66,14 +66,15 @@ void auto_init_reed_sensor_driver(void)
             LOG_ERROR("[auto_init_saul] error initializing rsd #%u\n", i);
             continue;
         }
-
+        LOG_DEBUG("SUCCESS\n");
         saul_entries[(i * 2)].dev = &(rsd_devs[i]);
         saul_entries[(i * 2)].name = reed_sensor_driver_saul_info[i].name;
         saul_entries[(i * 2)].driver = &reed_sensor_nc_saul_driver;
-        saul_entries[(i * 2) + 1].dev = &(rsd_devs[i]);
-        saul_entries[(i * 2) + 1].name = reed_sensor_driver_saul_info[i].name;
-        saul_entries[(i * 2) + 1].driver = &reed_sensor_no_saul_driver;
         saul_reg_add(&(saul_entries[(i * 2)]));
+
+        saul_entries[(i * 2) + 1].dev = &(rsd_devs[i]);
+        saul_entries[(i * 2) + 1].name = reed_sensor_driver_saul_info[i+1].name;
+        saul_entries[(i * 2) + 1].driver = &reed_sensor_no_saul_driver;
         saul_reg_add(&(saul_entries[(i * 2) + 1]));
     }
 }

--- a/drivers/saul/init_devs/auto_init_reed_sensor_driver.c
+++ b/drivers/saul/init_devs/auto_init_reed_sensor_driver.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     reed_sensor_driver
+ * @{
+ * @ingroup     sys_auto_init_saul
+ * @brief       Auto initialization of reed sensor driver
+ * @author      Timon Rupelt <timon.rupelt@haw-hamburg.de>
+ * @file
+ * @}
+ */
+
+
+#include "assert.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "reed_sensor_driver.h"
+#include "reed_sensor_driver_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define RSD_NUM     ARRAY_SIZE(reed_sensor_driver_params)
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static reed_sensor_driver_t rsd_devs[RSD_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[RSD_NUM * 2];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define RSD_INFO_NUM ARRAY_SIZE(reed_sensor_driver_saul_info)
+
+/**
+ * @name    Import SAUL endpoints
+ * @{
+ */
+extern saul_driver_t reed_sensor_nc_saul_driver;
+extern saul_driver_t reed_sensor_no_saul_driver;
+
+/** @} */
+
+
+
+
+void auto_init_reed_sensor_driver(void)
+{
+    assert(RSD_INFO_NUM == RSD_NUM);
+
+    for (unsigned int i = 0; i < RSD_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing rsd #%u\n", i);
+
+        if (reed_sensor_driver_init(&rsd_devs[i], &reed_sensor_driver_params[i]) != 0) {
+            LOG_ERROR("[auto_init_saul] error initializing rsd #%u\n", i);
+            continue;
+        }
+
+        saul_entries[(i * 2)].dev = &(rsd_devs[i]);
+        saul_entries[(i * 2)].name = reed_sensor_driver_saul_info[i].name;
+        saul_entries[(i * 2)].driver = &reed_sensor_nc_saul_driver;
+        saul_entries[(i * 2) + 1].dev = &(rsd_devs[i]);
+        saul_entries[(i * 2) + 1].name = reed_sensor_driver_saul_info[i].name;
+        saul_entries[(i * 2) + 1].driver = &reed_sensor_no_saul_driver;
+        saul_reg_add(&(saul_entries[(i * 2)]));
+        saul_reg_add(&(saul_entries[(i * 2) + 1]));
+    }
+}

--- a/drivers/saul/init_devs/auto_init_reed_sensor_driver.c
+++ b/drivers/saul/init_devs/auto_init_reed_sensor_driver.c
@@ -16,8 +16,6 @@
  * @}
  */
 
-
-#include "assert.h"
 #include "log.h"
 #include "saul_reg.h"
 #include "reed_sensor_driver.h"
@@ -26,7 +24,7 @@
 /**
  * @brief   Define the number of configured sensors
  */
-#define RSD_NUM     ARRAY_SIZE(reed_sensor_driver_params)
+#define RSD_NUM ARRAY_SIZE(reed_sensor_driver_params)
 
 /**
  * @brief   Allocate memory for the device descriptors
@@ -53,12 +51,8 @@ extern saul_driver_t reed_sensor_no_saul_driver;
 /** @} */
 
 
-#define ENABLE_DEBUG 1
-#include "debug.h"
-
 void auto_init_reed_sensor_driver(void)
 {
-
     for (unsigned int i = 0; i < RSD_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing rsd #%u\n", i);
 
@@ -73,7 +67,7 @@ void auto_init_reed_sensor_driver(void)
         saul_reg_add(&(saul_entries[(i * 2)]));
 
         saul_entries[(i * 2) + 1].dev = &(rsd_devs[i]);
-        saul_entries[(i * 2) + 1].name = reed_sensor_driver_saul_info[i+1].name;
+        saul_entries[(i * 2) + 1].name = reed_sensor_driver_saul_info[i + 1].name;
         saul_entries[(i * 2) + 1].driver = &reed_sensor_no_saul_driver;
         saul_reg_add(&(saul_entries[(i * 2) + 1]));
     }

--- a/drivers/saul/init_devs/init.c
+++ b/drivers/saul/init_devs/init.c
@@ -263,6 +263,10 @@ void saul_init_devs(void)
         extern void auto_init_qmc5883l(void);
         auto_init_qmc5883l();
     }
+    if (IS_USED(MODULE_REED_SENSOR_DRIVER)) {
+        extern void auto_init_reed_sensor_driver(void);
+        auto_init_reed_sensor_driver();
+    }
     if (IS_USED(MODULE_SCD30)) {
         extern void auto_init_scd30(void);
         auto_init_scd30();


### PR DESCRIPTION
### Contribution description
A generic device driver for reed sensor. Supports 3-Way (Form-C) reed switches with normaly-open and normaly-open contacts, but is also useable with just one. Driver supports configuration of debouncing delay and use of internal pulldown resistor.
