### PR TITLE
fixed reed driver not following selected mode when not using interrupts

### DIFF
--- a/drivers/reed_sensor_driver/reed_sensor_driver.c
+++ b/drivers/reed_sensor_driver/reed_sensor_driver.c
@@ -37,7 +37,7 @@ int reed_sensor_driver_init(reed_sensor_driver_t *dev, const reed_sensor_driver_
                       (void*) params);
     }
     else {
-        gpio_init(params->nc_pin, GPIO_IN);
+        gpio_init(params->nc_pin, mode);
     }
 
     /* Init normally-open pin */
@@ -46,7 +46,7 @@ int reed_sensor_driver_init(reed_sensor_driver_t *dev, const reed_sensor_driver_
                       (void *)params);
     }
     else {
-        gpio_init(params->no_pin, GPIO_IN);
+        gpio_init(params->no_pin, mode);
     }
 
     return 0;


### PR DESCRIPTION
### Contribution description

Fixing an oversight whereby the selected pin mode was not used when no interrupts were selected.


